### PR TITLE
Update documentation.md (#258)

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -1028,7 +1028,7 @@ Note that when using the `is` attribute, the tag name should be rendered in all 
     riot.mount('MyComponent');
   </script>
 ```
-
+Note that you can use `is` attribute with any HTML tags, but not with [`template` tag](#fragments-loops).
 
 ## Server-side rendering
 


### PR DESCRIPTION
added "Note that you can use `is` attribute with any HTML tags, but not with [`template` tag](#fragments-loops)." as suggested in https://github.com/riot/riot/issues/2742#issuecomment-517576194